### PR TITLE
Bump beast.version to 2.8.0-beta4 and surefire to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>25</maven.compiler.release>
 
-        <beast.version>2.8.0-SNAPSHOT</beast.version>
+        <beast.version>2.8.0-beta4</beast.version>
         <javafx.version>25.0.2</javafx.version>
         <beast.module>beast.base</beast.module>
         <beast.main>beast.base.minimal.BeastMain</beast.main>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
                     <argLine>


### PR DESCRIPTION
## Summary
- Bump `beast.version` from `2.8.0-SNAPSHOT` to `2.8.0-beta4` (latest released BEAST 3 on Maven Central)
- Bump `maven-surefire-plugin` from `3.1.2` to `3.5.2` (matches gold standard)

## Why
The `2.8.0-SNAPSHOT` dependency required everyone building Mascot to first install BEAST 3 SNAPSHOT to their local Maven repo. Pinning to the published `2.8.0-beta4` makes a fresh checkout build out of the box.

## Test plan
- [x] `mvn test` passes (4/4 tests, MascotTest + Euler2ndOrderTest)