### PR TITLE
Bump beast.version to 2.8.0-beta5 and surefire to 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>25</maven.compiler.release>
 
-        <beast.version>2.8.0-SNAPSHOT</beast.version>
+        <beast.version>2.8.0-beta5</beast.version>
         <javafx.version>25.0.2</javafx.version>
         <beast.module>beast.base</beast.module>
         <beast.main>beast.base.minimal.BeastMain</beast.main>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
                     <argLine>


### PR DESCRIPTION
Bumps `beast.version` from `2.8.0-SNAPSHOT` (which is not on Maven Central, breaking master CI) to `2.8.0-beta5`, and bumps `maven-surefire-plugin` from 3.1.2 to 3.5.2.

Replaces #18 (which was opened from a personal fork; we no longer use forks for these CompEvol repos).