### PR TITLE
ci: clean-deploy on tag and skip redundant verify

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -44,11 +44,12 @@ jobs:
           mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
 
       - name: Build and test
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         run: mvn verify
 
       - name: Publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/v')
-        run: mvn deploy -Prelease -DskipTests
+        run: mvn -Prelease clean deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>25</maven.compiler.release>
 
-        <beast.version>2.8.0-SNAPSHOT</beast.version>
+        <beast.version>2.8.0-beta5</beast.version>
         <javafx.version>25.0.2</javafx.version>
         <beast.module>beast.base</beast.module>
         <beast.main>beast.base.minimal.BeastMain</beast.main>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
                     <argLine>


### PR DESCRIPTION
CI workflow refinement: on tag publishes, run a clean deploy and skip the redundant verify pass.

Stacked on top of #20 (the beast.version bump). After #20 merges, this PR will only show the CI workflow change.

Replaces #19 (which was opened from a personal fork; we no longer use forks for these CompEvol repos).