### PR TITLE
Bump project version to 3.1.0-beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.compevol</groupId>
     <artifactId>mascot</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0-beta1</version>
 
     <name>Mascot</name>
     <description>BEAST 3 package for MASCOT - Marginal Approximation of the Structured Coalescent</description>


### PR DESCRIPTION
Bumps Mascot project version from 3.1.0-SNAPSHOT to 3.1.0-beta1 in preparation for the beta1 release tag.