### PR TITLE
Update repo URLs and Nicola's name spelling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
             <name>Nicola F. Müller</name>
             <url>https://github.com/nicfel</url>
         </developer>
+        <developer>
+            <name>Remco Bouckaert</name>
+            <url>https://github.com/rbouckaert</url>
+        </developer>
     </developers>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <developers>
         <developer>
-            <name>Nicola F. Mueller</name>
+            <name>Nicola F. Müller</name>
             <url>https://github.com/nicfel</url>
         </developer>
     </developers>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>Mascot</name>
     <description>BEAST 3 package for MASCOT - Marginal Approximation of the Structured Coalescent</description>
 
-    <url>https://github.com/nicfel/Mascot</url>
+    <url>https://github.com/CompEvol/Mascot</url>
 
     <licenses>
         <license>
@@ -28,9 +28,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/nicfel/Mascot.git</connection>
-        <developerConnection>scm:git:ssh://github.com:nicfel/Mascot.git</developerConnection>
-        <url>https://github.com/nicfel/Mascot</url>
+        <connection>scm:git:git://github.com/CompEvol/Mascot.git</connection>
+        <developerConnection>scm:git:ssh://github.com:CompEvol/Mascot.git</developerConnection>
+        <url>https://github.com/CompEvol/Mascot</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
Updates the project `<url>`, SCM `<connection>`, `<developerConnection>`, and SCM `<url>` to point at CompEvol/Mascot now that the repo has been transferred. Also corrects the developer name to Nicola's preferred form 'Nicola F. Müller' (per his Google Scholar profile). Developer profile URL is left unchanged.