### PR TITLE
Update in-code citations and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A tutorial on how to use MASCOT can be found [here](https://taming-the-beast.org
 <dependency>
     <groupId>io.github.compevol</groupId>
     <artifactId>mascot</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.0-beta1</version>
 </dependency>
 ```
 
@@ -29,6 +29,16 @@ mvn install -DskipTests
 ```bash
 mvn exec:exec -Dbeast.args="-overwrite examples/Constant.xml"
 ```
+
+## Citation
+
+Müller NF, Bouckaert RR, Wu C-H, Bedford T. *MASCOT-Skyline integrates population and migration dynamics to enhance phylogeographic reconstructions.* PLOS Computational Biology 21(9):e1013421, 2025. [DOI:10.1371/journal.pcbi.1013421](https://doi.org/10.1371/journal.pcbi.1013421)
+
+Müller NF, Dudas G, Stadler T. *Inferring time-dependent migration and coalescence patterns from genetic sequence and predictor data in structured populations.* Virus Evolution 5(2):vez030, 2019. [DOI:10.1093/ve/vez030](https://doi.org/10.1093/ve/vez030)
+
+Müller NF, Rasmussen DA, Stadler T. *MASCOT: parameter and state inference under the marginal structured coalescent approximation.* Bioinformatics 34(22):3843–3848, 2018. [DOI:10.1093/bioinformatics/bty406](https://doi.org/10.1093/bioinformatics/bty406)
+
+Müller NF, Rasmussen DA, Stadler T. *The Structured Coalescent and Its Approximations.* Molecular Biology and Evolution 34(11):2970–2981, 2017. [DOI:10.1093/molbev/msx186](https://doi.org/10.1093/molbev/msx186)
 
 ## License
 

--- a/src/main/java/mascot/dynamics/GLM.java
+++ b/src/main/java/mascot/dynamics/GLM.java
@@ -14,10 +14,10 @@ import java.util.HashMap;
 
 @Description("Extracts the intervals from a tree. Points in the intervals " +
         "are defined by the heights of nodes in the tree.")
-@Citation(	"Nicola F. Müller, Gytis Dudas, Tanja Stadler (2018)\n"+
+@Citation(	"Nicola F. Müller, Gytis Dudas, Tanja Stadler (2019)\n"+
 			"  Inferring time-dependent migration and coalescence patterns\n" +
 			"  from genetic sequence and predictor data in structured populations\n"+
-			"  bioRxiv, doi: bty406, 10.1101/342329")
+			"  Virus Evolution 5(2):vez030, https://doi.org/10.1093/ve/vez030")
 public class GLM extends Dynamics implements Loggable {	
     
 	public Input<GlmModel> migrationGLMInput = new Input<>(

--- a/src/main/java/mascot/dynamics/GLMWithSkylineNe.java
+++ b/src/main/java/mascot/dynamics/GLMWithSkylineNe.java
@@ -15,10 +15,11 @@ import java.util.HashMap;
 
 @Description("Extracts the intervals from a tree. Points in the intervals " +
         "are defined by the heights of nodes in the tree.")
-@Citation(	"Nicola F. Müller, Gytis Dudas, Tanja Stadler (2018)\n"+
-			"  Inferring time-dependent migration and coalescence patterns\n" +
-			"  from genetic sequence and predictor data in structured populations\n"+
-			"  bioRxiv, doi: bty406, 10.1101/342329")
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
 public class GLMWithSkylineNe extends Dynamics implements Loggable {	
     
 	public Input<GlmModel> migrationGLMInput = new Input<>(

--- a/src/main/java/mascot/dynamics/StructuredMigrationSkyline.java
+++ b/src/main/java/mascot/dynamics/StructuredMigrationSkyline.java
@@ -1,6 +1,7 @@
 package mascot.dynamics;
 
 
+import beast.base.core.Citation;
 import beast.base.core.Description;
 import beast.base.core.Input;
 import beast.base.core.Input.Validate;
@@ -12,6 +13,11 @@ import java.io.PrintStream;
 
 
 @Description("Wrapper class that takes parametric and non parametric dynamics as input.")
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
 public class StructuredMigrationSkyline extends Dynamics implements Loggable {
         
     public Input<NeDynamicsList> NeFunctionInput = new Input<>(

--- a/src/main/java/mascot/dynamics/StructuredSkyline.java
+++ b/src/main/java/mascot/dynamics/StructuredSkyline.java
@@ -1,6 +1,7 @@
 package mascot.dynamics;
 
 
+import beast.base.core.Citation;
 import beast.base.core.Description;
 import beast.base.core.Input;
 import beast.base.core.Input.Validate;
@@ -14,7 +15,12 @@ import java.io.PrintStream;
 
 
 @Description("Wrapper class that takes parametric and non parametric dynamics as input.")
-public class StructuredSkyline extends Dynamics implements Loggable {	
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
+public class StructuredSkyline extends Dynamics implements Loggable {
         
     public Input<NeDynamicsList> parametricFunctionInput = new Input<>(
     		"NeDynamics", "input of the log effective population sizes", Validate.REQUIRED);    

--- a/src/main/java/mascot/skyline/GLMPrior.java
+++ b/src/main/java/mascot/skyline/GLMPrior.java
@@ -1,5 +1,6 @@
 package mascot.skyline;
 
+import beast.base.core.Citation;
 import beast.base.core.Input;
 import beast.base.inference.Distribution;
 import beast.base.inference.State;
@@ -16,6 +17,11 @@ import mascot.parameterdynamics.Skygrowth;
 import java.util.List;
 import java.util.Random;
 
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
 public class GLMPrior extends Distribution {
 
     public Input<CovariateList> covariateListInput = new Input<>("covariateList", "input of covariates", Input.Validate.REQUIRED);

--- a/src/main/java/mascot/skyline/GrowthRateSmoothingPrior.java
+++ b/src/main/java/mascot/skyline/GrowthRateSmoothingPrior.java
@@ -1,5 +1,6 @@
 package mascot.skyline;
 
+import beast.base.core.Citation;
 import beast.base.core.Input;
 import beast.base.core.Input.Validate;
 import beast.base.inference.Distribution;
@@ -12,6 +13,11 @@ import mascot.dynamics.RateShifts;
 import java.util.List;
 import java.util.Random;
 
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
 public class GrowthRateSmoothingPrior extends Distribution {
 	
     public Input<RealVectorParam<? extends Real>> NeLogInput = new Input<>(

--- a/src/main/java/mascot/skyline/LogSmoothingPrior.java
+++ b/src/main/java/mascot/skyline/LogSmoothingPrior.java
@@ -1,5 +1,6 @@
 package mascot.skyline;
 
+import beast.base.core.Citation;
 import beast.base.core.Input;
 import beast.base.core.Input.Validate;
 import beast.base.inference.Distribution;
@@ -11,6 +12,11 @@ import beast.base.spec.inference.parameter.RealVectorParam;
 import java.util.List;
 import java.util.Random;
 
+@Citation(	"Nicola F. Müller, Remco R. Bouckaert, Chieh-Hsi Wu, Trevor Bedford (2025)\n"+
+			"  MASCOT-Skyline integrates population and migration dynamics\n"+
+			"  to enhance phylogeographic reconstructions\n"+
+			"  PLOS Computational Biology 21(9):e1013421,\n"+
+			"  https://doi.org/10.1371/journal.pcbi.1013421")
 public class LogSmoothingPrior extends Distribution {
 	
     public Input<RealVectorParam<? extends Real>> NeLogInput = new Input<>(


### PR DESCRIPTION
Update in-code citations and README

Fix malformed @Citation in GLM.java and GLMWithSkylineNe.java that mixed
the GLM paper title with the original MASCOT paper DOI suffix (bty406)
and the bioRxiv URL. Replace with the correct published citations:
  - GLM.java: Müller, Dudas, Stadler 2019 (Virus Evolution, vez030)
  - GLMWithSkylineNe.java: Müller, Bouckaert, Wu, Bedford 2025 (Skyline)

Add MASCOT-Skyline @Citation to five skyline classes that had none:
StructuredSkyline, StructuredMigrationSkyline, LogSmoothingPrior,
GrowthRateSmoothingPrior, GLMPrior. BEAST dedupes citations by text,
so the identical annotation across these classes collapses to a single
line in the "Citations for this model" output.

README: add Citation section with all four MASCOT papers (including the
2017 MBE precursor) and bump the Maven coordinates snippet to
3.1.0-beta1 to match the project version.
